### PR TITLE
Move accent to protocol

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,6 +65,26 @@ Button("Text Button", action: {})
 
 ![Text Button](docs/img/TextButton.gif)
 
+#### Color
+
+In iOS and WatchOS, you can set the color through the accentColor modifier
+
+```swift
+        Button("Contained Button", action: {})
+        .buttonStyle(ContainedButtonStyle())
+            .accentColor(Color.green)
+```
+
+In MacOS the accentColor modifier is not available, so you can use the materialColor environment variable
+(in fact, you can use this on any platform)
+
+
+```swift
+        Button("Contained Button", action: {})
+        .buttonStyle(ContainedButtonStyle())
+        .environment(\.materialAccent, Color.red)
+```
+
 #### Modifiers
 
 MaterialUI also supplies some modifiers you can apply to any SwiftUI View:

--- a/Readme.md
+++ b/Readme.md
@@ -75,7 +75,7 @@ In iOS and WatchOS, you can set the color through the accentColor modifier
             .accentColor(Color.green)
 ```
 
-In MacOS the accentColor modifier is not available, so you can use the materialColor environment variable
+In MacOS the accentColor modifier is not available, so you can use the materialAccent environment variable
 (in fact, you can use this on any platform)
 
 

--- a/Sources/MaterialUI/Button.swift
+++ b/Sources/MaterialUI/Button.swift
@@ -29,7 +29,7 @@ struct MaterialButtonContent: ViewModifier {
 public struct ContainedButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
-        @Environment(\.materialAccent) var accentColor: Color
+		@Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{

--- a/Sources/MaterialUI/Button.swift
+++ b/Sources/MaterialUI/Button.swift
@@ -29,6 +29,7 @@ struct MaterialButtonContent: ViewModifier {
 public struct ContainedButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
+        @Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{
@@ -36,7 +37,7 @@ public struct ContainedButtonStyle: PrimitiveButtonStyle {
 				.modifier(MaterialButtonContent())
 				.ripple(Color.white, cornerRadius: 4) // FIXME: should be foregroundColor
 				.foregroundColor(Color.white) // FIXME: should be foregroundColor
-				.background(isEnabled ? Color.accentColor : Color.gray)
+				.background(isEnabled ? accentColor : Color.gray)
 				.cornerRadius(4)
 				.elevation(enabled: 2, hover: 4, mouseDown: 8)
 		}
@@ -58,16 +59,17 @@ public struct ContainedButtonStyle: PrimitiveButtonStyle {
 public struct OutlinedButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
+        @Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{
 			content
 				.modifier(MaterialButtonContent())
-				.ripple(Color.accentColor, cornerRadius: 4)
-				.foregroundColor(isEnabled ? Color.accentColor : Color.gray)
+				.ripple(accentColor, cornerRadius: 4)
+				.foregroundColor(isEnabled ? accentColor : Color.gray)
 				.overlay(
 					RoundedRectangle(cornerRadius: 4)
-						.stroke(isEnabled ? Color.accentColor : Color.gray)
+						.stroke(isEnabled ? accentColor : Color.gray)
 				)
 		}
 	}
@@ -88,13 +90,14 @@ public struct OutlinedButtonStyle: PrimitiveButtonStyle {
 public struct TextButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
+        @Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{
 			content
 				.modifier(MaterialButtonContent(xPadding: 8))
-				.ripple(Color.accentColor, cornerRadius: 4)
-				.foregroundColor(isEnabled ? Color.accentColor : Color.gray)
+				.ripple(accentColor, cornerRadius: 4)
+				.foregroundColor(isEnabled ? accentColor : Color.gray)
 		}
 	}
 

--- a/Sources/MaterialUI/Button.swift
+++ b/Sources/MaterialUI/Button.swift
@@ -90,7 +90,7 @@ public struct OutlinedButtonStyle: PrimitiveButtonStyle {
 public struct TextButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
-        @Environment(\.materialAccent) var accentColor: Color
+		@Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{

--- a/Sources/MaterialUI/Button.swift
+++ b/Sources/MaterialUI/Button.swift
@@ -59,7 +59,7 @@ public struct ContainedButtonStyle: PrimitiveButtonStyle {
 public struct OutlinedButtonStyle: PrimitiveButtonStyle {
 	private struct LabelModifier: ViewModifier {
 		@Environment(\.isEnabled) var isEnabled: Bool
-        @Environment(\.materialAccent) var accentColor: Color
+		@Environment(\.materialAccent) var accentColor: Color
 
 		func body(content: Content) -> some View
 		{

--- a/Sources/MaterialUI/MaterialColor.swift
+++ b/Sources/MaterialUI/MaterialColor.swift
@@ -26,11 +26,9 @@ extension EnvironmentValues {
     var materialAccent: Color {
         get {
             let color = self[MaterialAccentColorKey.self]
-            print("color get: \(color)")
             return color
         }
         set {
-            print("color set: \(newValue)")
             self[MaterialAccentColorKey.self] = newValue
         }
     }

--- a/Sources/MaterialUI/MaterialColor.swift
+++ b/Sources/MaterialUI/MaterialColor.swift
@@ -1,0 +1,37 @@
+//
+//  MaterialColor.swift
+//  MaterialUIMac
+//
+//  Created by Rob Jonson on 11/07/2020.
+//  Copyright © 2020 HobbyistSoftware. All rights reserved.
+//
+
+import SwiftUI
+
+
+//introduce custom environment key to allow setting accent colour in MacOS
+//https://medium.com/@SergDort/custom-environment-keys-in-swiftui-49f54a13d140
+struct MaterialAccentColorKey: EnvironmentKey {
+    static let defaultValue: Color = Color.accentColor
+}
+
+extension EnvironmentValues {
+    
+    /// Use to set accent colour in MacOS
+    /// e.g.
+    ///
+    ///    Button("Outlined Button", action: {})
+    ///    .buttonStyle(OutlinedButtonStyle())
+    ///    .environment(\.materialAccent, Color.green)
+    var materialAccent: Color {
+        get {
+            let color = self[MaterialAccentColorKey.self]
+            print("color get: \(color)")
+            return color
+        }
+        set {
+            print("color set: \(newValue)")
+            self[MaterialAccentColorKey.self] = newValue
+        }
+    }
+}

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -11,7 +11,7 @@ import SwiftUI
 public struct MaterialSwitchToggleStyle: ToggleStyle {
 	@Environment(\.materialAccent) var accentColor: Color
     
-    // https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
+	// https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
 	// FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
 	static let _kTrackHeight: CGFloat = 14.0;
 	static let _kTrackWidth: CGFloat = 33.0;

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -9,97 +9,106 @@
 import SwiftUI
 
 public struct MaterialSwitchToggleStyle: ToggleStyle {
-	@Environment(\.materialAccent) var accentColor: Color
-    
-    // https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
-	// FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
-	static let _kTrackHeight: CGFloat = 14.0;
-	static let _kTrackWidth: CGFloat = 33.0;
-	static let _kTrackRadius: CGFloat = _kTrackHeight / 2.0;
-	static let _kThumbRadius: CGFloat = 10.0;
+     private struct Switch: View {
+          var configuration:MaterialSwitchToggleStyle.Configuration
+          
+          @Environment(\.materialAccent) var accentColor: Color
+          
+          // https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
+          // FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
+          static let _kTrackHeight: CGFloat = 14.0;
+          static let _kTrackWidth: CGFloat = 33.0;
+          static let _kTrackRadius: CGFloat = _kTrackHeight / 2.0;
+          static let _kThumbRadius: CGFloat = 10.0;
 
-	// https://github.com/flutter/flutter/blob/a1c5e3354be7e0c391447d958bc546629bbe148a/packages/flutter/lib/src/material/toggleable.dart#L14
-	// FIXME: ^^ above says 0.2 but material.io is much faster
-	static let _kToggleDuration: Double = 0.1
+          // https://github.com/flutter/flutter/blob/a1c5e3354be7e0c391447d958bc546629bbe148a/packages/flutter/lib/src/material/toggleable.dart#L14
+          // FIXME: ^^ above says 0.2 but material.io is much faster
+          static let _kToggleDuration: Double = 0.1
 
-	static let thumbDiameter = _kThumbRadius * 2
+          static let thumbDiameter = _kThumbRadius * 2
+          
+          
+            var body: some View
+          {
+                let anim = Animation.linear(duration: Self._kToggleDuration)
+                let offset = CGSize(width: configuration.isOn ? Self._kThumbRadius : -Self._kThumbRadius, height: 0)
+                return ZStack {
+                     // track
+                     RoundedRectangle(cornerRadius: Self._kTrackRadius)
+                          .fill((configuration.isOn ? accentColor : Color.gray).opacity(0.54))
+                          .frame(width: Self._kTrackWidth, height: Self._kTrackHeight)
 
-	public init()
-	{
-	}
+                     // thumb
+                     Circle()
+                          .fill(configuration.isOn ? accentColor : Color.white)
+                          .frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
+                          .offset(offset)
+                          .animation(anim)
+                          .elevation(2)
+                     }
+                     .modifier(DisabledFader())
+                     .radialRipple(configuration.isOn ? accentColor : Color.primary, offset: offset)
+                     .animation(anim)
+                .modifier(PointerObserver(action: { self.configuration.isOn.toggle() }))
+          }
+          
+     }
 
-	func makeSwitch(_ configuration: Self.Configuration) -> some View
-	{
-		let anim = Animation.linear(duration: Self._kToggleDuration)
-		let offset = CGSize(width: configuration.isOn ? Self._kThumbRadius : -Self._kThumbRadius, height: 0)
-		return ZStack {
-			// track
-			RoundedRectangle(cornerRadius: Self._kTrackRadius)
-				.fill((configuration.isOn ? accentColor : Color.gray).opacity(0.54))
-				.frame(width: Self._kTrackWidth, height: Self._kTrackHeight)
+    public init()
+    {
+    }
 
-			// thumb
-			Circle()
-				.fill(configuration.isOn ? accentColor : Color.white)
-				.frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
-				.offset(offset)
-				.animation(anim)
-				.elevation(2)
-			}
-			.modifier(DisabledFader())
-			.radialRipple(configuration.isOn ? accentColor : Color.primary, offset: offset)
-			.animation(anim)
-			.modifier(PointerObserver(action: { configuration.isOn.toggle() }))
-	}
 
-	public func makeBody(configuration: Self.Configuration) -> some View
-	{
-		HStack {
-			configuration.label
-			Spacer()
-			makeSwitch(configuration)
-		}
-	}
+
+    public func makeBody(configuration: Self.Configuration) -> some View
+    {
+        HStack {
+            configuration.label
+            Spacer()
+                Switch(configuration:configuration)
+        }
+    }
 }
 
 
 #if DEBUG
 struct Toggle_Previews: PreviewProvider {
-	static var toggles: some View {
-		VStack {
-			Toggle("Toggle On", isOn: Binding.constant(true))
-			Toggle("Toggle Off", isOn: Binding.constant(false))
-		}.padding(10)
-	}
+    static var toggles: some View {
+        VStack {
+            Toggle("Toggle On", isOn: Binding.constant(true))
+            Toggle("Toggle Off", isOn: Binding.constant(false))
+        }.padding(10)
+    }
 
-	static var previews: some View {
-		Group {
-			toggles
-				.toggleStyle(DefaultToggleStyle())
-				.previewDisplayName("DefaultToggleStyle")
-				.previewLayout(.fixed(width: 200, height: 150))
+    static var previews: some View {
+        Group {
+            toggles
+                .toggleStyle(DefaultToggleStyle())
+                .previewDisplayName("DefaultToggleStyle")
+                .previewLayout(.fixed(width: 200, height: 150))
 
-			toggles
-				.toggleStyle(SwitchToggleStyle())
-				.previewDisplayName("SwitchToggleStyle")
-				.previewLayout(.fixed(width: 200, height: 150))
+            toggles
+                .toggleStyle(SwitchToggleStyle())
+                .previewDisplayName("SwitchToggleStyle")
+                .previewLayout(.fixed(width: 200, height: 150))
 
-			toggles
-				.toggleStyle(MaterialSwitchToggleStyle())
-				.previewDisplayName("MaterialSwitchToggleStyle")
-				.previewLayout(.fixed(width: 200, height: 150))
+            toggles
+                .toggleStyle(MaterialSwitchToggleStyle())
+                .previewDisplayName("MaterialSwitchToggleStyle")
+                .previewLayout(.fixed(width: 200, height: 150))
 
-			List(["Foo", "Bar", "Baz"], id: \.self) { label in
-				Toggle(label, isOn: Binding.constant(true))
-			}
-			.previewLayout(.fixed(width: 200, height: 150))
+            List(["Foo", "Bar", "Baz"], id: \.self) { label in
+                Toggle(label, isOn: Binding.constant(true))
+            }
+            .previewLayout(.fixed(width: 200, height: 150))
 
-			List(["Foo", "Bar", "Baz"], id: \.self) { label in
-				Toggle(label, isOn: Binding.constant(true))
-			}
-			.toggleStyle(MaterialSwitchToggleStyle())
-			.previewLayout(.fixed(width: 200, height: 150))
-		}
-	}
+            List(["Foo", "Bar", "Baz"], id: \.self) { label in
+                Toggle(label, isOn: Binding.constant(true))
+            }
+            .toggleStyle(MaterialSwitchToggleStyle())
+            .previewLayout(.fixed(width: 200, height: 150))
+        }
+    }
 }
 #endif
+

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -9,7 +9,9 @@
 import SwiftUI
 
 public struct MaterialSwitchToggleStyle: ToggleStyle {
-	// https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
+	@Environment(\.materialAccent) var accentColor: Color
+    
+    // https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
 	// FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
 	static let _kTrackHeight: CGFloat = 14.0;
 	static let _kTrackWidth: CGFloat = 33.0;
@@ -33,19 +35,19 @@ public struct MaterialSwitchToggleStyle: ToggleStyle {
 		return ZStack {
 			// track
 			RoundedRectangle(cornerRadius: Self._kTrackRadius)
-				.fill((configuration.isOn ? Color.accentColor : Color.gray).opacity(0.54))
+				.fill((configuration.isOn ? accentColor : Color.gray).opacity(0.54))
 				.frame(width: Self._kTrackWidth, height: Self._kTrackHeight)
 
 			// thumb
 			Circle()
-				.fill(configuration.isOn ? Color.accentColor : Color.white)
+				.fill(configuration.isOn ? accentColor : Color.white)
 				.frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
 				.offset(offset)
 				.animation(anim)
 				.elevation(2)
 			}
 			.modifier(DisabledFader())
-			.radialRipple(configuration.isOn ? Color.accentColor : Color.primary, offset: offset)
+			.radialRipple(configuration.isOn ? accentColor : Color.primary, offset: offset)
 			.animation(anim)
 			.modifier(PointerObserver(action: { configuration.isOn.toggle() }))
 	}

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -9,106 +9,106 @@
 import SwiftUI
 
 public struct MaterialSwitchToggleStyle: ToggleStyle {
-     private struct Switch: View {
-          var configuration:MaterialSwitchToggleStyle.Configuration
-          
-          @Environment(\.materialAccent) var accentColor: Color
-          
-          // https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
-          // FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
-          static let _kTrackHeight: CGFloat = 14.0;
-          static let _kTrackWidth: CGFloat = 33.0;
-          static let _kTrackRadius: CGFloat = _kTrackHeight / 2.0;
-          static let _kThumbRadius: CGFloat = 10.0;
-
-          // https://github.com/flutter/flutter/blob/a1c5e3354be7e0c391447d958bc546629bbe148a/packages/flutter/lib/src/material/toggleable.dart#L14
-          // FIXME: ^^ above says 0.2 but material.io is much faster
-          static let _kToggleDuration: Double = 0.1
-
-          static let thumbDiameter = _kThumbRadius * 2
-          
-          
-            var body: some View
-          {
-                let anim = Animation.linear(duration: Self._kToggleDuration)
-                let offset = CGSize(width: configuration.isOn ? Self._kThumbRadius : -Self._kThumbRadius, height: 0)
-                return ZStack {
-                     // track
-                     RoundedRectangle(cornerRadius: Self._kTrackRadius)
-                          .fill((configuration.isOn ? accentColor : Color.gray).opacity(0.54))
-                          .frame(width: Self._kTrackWidth, height: Self._kTrackHeight)
-
-                     // thumb
-                     Circle()
-                          .fill(configuration.isOn ? accentColor : Color.white)
-                          .frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
-                          .offset(offset)
-                          .animation(anim)
-                          .elevation(2)
-                     }
-                     .modifier(DisabledFader())
-                     .radialRipple(configuration.isOn ? accentColor : Color.primary, offset: offset)
-                     .animation(anim)
-                .modifier(PointerObserver(action: { self.configuration.isOn.toggle() }))
-          }
-          
-     }
-
-    public init()
-    {
-    }
-
-
-
-    public func makeBody(configuration: Self.Configuration) -> some View
-    {
-        HStack {
-            configuration.label
-            Spacer()
-                Switch(configuration:configuration)
-        }
-    }
+	private struct Switch: View {
+		var configuration:MaterialSwitchToggleStyle.Configuration
+		
+		@Environment(\.materialAccent) var accentColor: Color
+		
+		// https://github.com/flutter/flutter/blob/ee032f67c734e607d8ea5c870ba744daf4bf56e7/packages/flutter/lib/src/material/switch.dart#L19
+		// FIXME: https://material.io/components/selection-controls/#specs says it should be 20 x 36 .. what gives?
+		static let _kTrackHeight: CGFloat = 14.0;
+		static let _kTrackWidth: CGFloat = 33.0;
+		static let _kTrackRadius: CGFloat = _kTrackHeight / 2.0;
+		static let _kThumbRadius: CGFloat = 10.0;
+		
+		// https://github.com/flutter/flutter/blob/a1c5e3354be7e0c391447d958bc546629bbe148a/packages/flutter/lib/src/material/toggleable.dart#L14
+		// FIXME: ^^ above says 0.2 but material.io is much faster
+		static let _kToggleDuration: Double = 0.1
+		
+		static let thumbDiameter = _kThumbRadius * 2
+		
+		
+		var body: some View
+		{
+			let anim = Animation.linear(duration: Self._kToggleDuration)
+			let offset = CGSize(width: configuration.isOn ? Self._kThumbRadius : -Self._kThumbRadius, height: 0)
+			return ZStack {
+				// track
+				RoundedRectangle(cornerRadius: Self._kTrackRadius)
+					.fill((configuration.isOn ? accentColor : Color.gray).opacity(0.54))
+					.frame(width: Self._kTrackWidth, height: Self._kTrackHeight)
+				
+				// thumb
+				Circle()
+					.fill(configuration.isOn ? accentColor : Color.white)
+					.frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
+					.offset(offset)
+					.animation(anim)
+					.elevation(2)
+			}
+			.modifier(DisabledFader())
+			.radialRipple(configuration.isOn ? accentColor : Color.primary, offset: offset)
+			.animation(anim)
+			.modifier(PointerObserver(action: { self.configuration.isOn.toggle() }))
+		}
+		
+	}
+	
+	public init()
+	{
+	}
+	
+	
+	
+	public func makeBody(configuration: Self.Configuration) -> some View
+	{
+		HStack {
+			configuration.label
+			Spacer()
+			Switch(configuration:configuration)
+		}
+	}
 }
 
 
 #if DEBUG
 struct Toggle_Previews: PreviewProvider {
-    static var toggles: some View {
-        VStack {
-            Toggle("Toggle On", isOn: Binding.constant(true))
-            Toggle("Toggle Off", isOn: Binding.constant(false))
-        }.padding(10)
-    }
-
-    static var previews: some View {
-        Group {
-            toggles
-                .toggleStyle(DefaultToggleStyle())
-                .previewDisplayName("DefaultToggleStyle")
-                .previewLayout(.fixed(width: 200, height: 150))
-
-            toggles
-                .toggleStyle(SwitchToggleStyle())
-                .previewDisplayName("SwitchToggleStyle")
-                .previewLayout(.fixed(width: 200, height: 150))
-
-            toggles
-                .toggleStyle(MaterialSwitchToggleStyle())
-                .previewDisplayName("MaterialSwitchToggleStyle")
-                .previewLayout(.fixed(width: 200, height: 150))
-
-            List(["Foo", "Bar", "Baz"], id: \.self) { label in
-                Toggle(label, isOn: Binding.constant(true))
-            }
-            .previewLayout(.fixed(width: 200, height: 150))
-
-            List(["Foo", "Bar", "Baz"], id: \.self) { label in
-                Toggle(label, isOn: Binding.constant(true))
-            }
-            .toggleStyle(MaterialSwitchToggleStyle())
-            .previewLayout(.fixed(width: 200, height: 150))
-        }
-    }
+	static var toggles: some View {
+		VStack {
+			Toggle("Toggle On", isOn: Binding.constant(true))
+			Toggle("Toggle Off", isOn: Binding.constant(false))
+		}.padding(10)
+	}
+	
+	static var previews: some View {
+		Group {
+			toggles
+				.toggleStyle(DefaultToggleStyle())
+				.previewDisplayName("DefaultToggleStyle")
+				.previewLayout(.fixed(width: 200, height: 150))
+			
+			toggles
+				.toggleStyle(SwitchToggleStyle())
+				.previewDisplayName("SwitchToggleStyle")
+				.previewLayout(.fixed(width: 200, height: 150))
+			
+			toggles
+				.toggleStyle(MaterialSwitchToggleStyle())
+				.previewDisplayName("MaterialSwitchToggleStyle")
+				.previewLayout(.fixed(width: 200, height: 150))
+			
+			List(["Foo", "Bar", "Baz"], id: \.self) { label in
+				Toggle(label, isOn: Binding.constant(true))
+			}
+			.previewLayout(.fixed(width: 200, height: 150))
+			
+			List(["Foo", "Bar", "Baz"], id: \.self) { label in
+				Toggle(label, isOn: Binding.constant(true))
+			}
+			.toggleStyle(MaterialSwitchToggleStyle())
+			.previewLayout(.fixed(width: 200, height: 150))
+		}
+	}
 }
 #endif
 


### PR DESCRIPTION
This works for buttons, though not for toggles.
I can't see why toggles fail as it's using the same approach