### PR TITLE
Limit animations to specific properties

### DIFF
--- a/Sources/MaterialUI/DisabledFader.swift
+++ b/Sources/MaterialUI/DisabledFader.swift
@@ -15,6 +15,6 @@ struct DisabledFader: ViewModifier {
 		content
 			.compositingGroup()
 			.opacity(isEnabled ? 1 : 0.5)
-            .animation(nil,value:isEnabled)
+			.animation(nil, value: isEnabled)
 	}
 }

--- a/Sources/MaterialUI/DisabledFader.swift
+++ b/Sources/MaterialUI/DisabledFader.swift
@@ -15,6 +15,6 @@ struct DisabledFader: ViewModifier {
 		content
 			.compositingGroup()
 			.opacity(isEnabled ? 1 : 0.5)
-			.animation(nil)
+            .animation(nil,value:isEnabled)
 	}
 }

--- a/Sources/MaterialUI/Elevation.swift
+++ b/Sources/MaterialUI/Elevation.swift
@@ -61,7 +61,7 @@ fileprivate struct Elevation: ViewModifier {
 			.shadow(color: Color.black.opacity(Self.kKeyShadowOpacity), radius: keyShadowBlur, x: 0, y: keyShadowYOff)
 
 			// FIXME: Is this the correct curve?
-            .animation(isEnabled ? Animation.easeInOut(duration: Self.kThemeChangeDuration) : nil,value:elevation)
+			.animation(isEnabled ? Animation.easeInOut(duration: Self.kThemeChangeDuration) : nil, value: elevation)
 			.modifier(PointerObserver(updating: $pointerState))
 	}
 }

--- a/Sources/MaterialUI/Elevation.swift
+++ b/Sources/MaterialUI/Elevation.swift
@@ -53,7 +53,7 @@ fileprivate struct Elevation: ViewModifier {
 	public func body(content: Content) -> some View
 	{
 		content
-			.animation(nil)
+            .animation(nil,value:elevation)
 			// top shadow
 			.shadow(color: Color.black.opacity(Self.kAmbientShadowOpacity), radius: ambientShadowBlur, x: 0, y: 0)
 
@@ -61,7 +61,7 @@ fileprivate struct Elevation: ViewModifier {
 			.shadow(color: Color.black.opacity(Self.kKeyShadowOpacity), radius: keyShadowBlur, x: 0, y: keyShadowYOff)
 
 			// FIXME: Is this the correct curve?
-			.animation(isEnabled ? Animation.easeInOut(duration: Self.kThemeChangeDuration) : nil)
+            .animation(isEnabled ? Animation.easeInOut(duration: Self.kThemeChangeDuration) : nil,value:elevation)
 			.modifier(PointerObserver(updating: $pointerState))
 	}
 }

--- a/Sources/MaterialUI/Elevation.swift
+++ b/Sources/MaterialUI/Elevation.swift
@@ -53,7 +53,7 @@ fileprivate struct Elevation: ViewModifier {
 	public func body(content: Content) -> some View
 	{
 		content
-            .animation(nil,value:elevation)
+			.animation(nil, value: elevation)
 			// top shadow
 			.shadow(color: Color.black.opacity(Self.kAmbientShadowOpacity), radius: ambientShadowBlur, x: 0, y: 0)
 

--- a/Sources/MaterialUI/Ripple.swift
+++ b/Sources/MaterialUI/Ripple.swift
@@ -60,7 +60,7 @@ fileprivate struct Ripple: ViewModifier {
 			.fixedSize(horizontal: !isRadial, vertical: !isRadial)
 			.offset(rippleOffset(mX, mY))
 			.scaleEffect(rippleAppeared ? 1 : Self.kRippleStartingScale)
-            .animation(.easeInOut(duration: isRadial ? Self.kRadialReactionDuration : Self.kRippleTouchDownDuration),value:rippleAppeared)
+			.animation(.easeInOut(duration: isRadial ? Self.kRadialReactionDuration : Self.kRippleTouchDownDuration), value: rippleAppeared)
 	}
 
 	public func body(content: Content) -> some View

--- a/Sources/MaterialUI/Ripple.swift
+++ b/Sources/MaterialUI/Ripple.swift
@@ -80,7 +80,7 @@ fileprivate struct Ripple: ViewModifier {
 						RoundedRectangle(cornerRadius: cornerRadius)
 							.fill(color.opacity(0.16))
 							.frame(width: dimension, height: dimension)
-							.animation(.linear(duration: Self.kRippleFadeInOutDuration),value:pointerState.isOver)
+							.animation(.linear(duration: Self.kRippleFadeInOutDuration), value: pointerState.isOver)
 							.mask(GeometryReader { self.rippleShape(for: $0.size) })
 							.onAppear { self.rippleAppeared = true }
 							.onDisappear { self.rippleAppeared = false }

--- a/Sources/MaterialUI/Ripple.swift
+++ b/Sources/MaterialUI/Ripple.swift
@@ -73,7 +73,7 @@ fileprivate struct Ripple: ViewModifier {
 						RoundedRectangle(cornerRadius: cornerRadius)
 							.fill(color.opacity(pointerState.isOver ? 0.08 : 0))
 							.frame(width: dimension, height: dimension)
-                            .animation(.linear(duration: Self.kRippleFadeInOutDuration),value:pointerState.isOver)
+							.animation(.linear(duration: Self.kRippleFadeInOutDuration), value: pointerState.isOver)
 					}
 					// ripple
 					if showRipple {

--- a/Sources/MaterialUI/Ripple.swift
+++ b/Sources/MaterialUI/Ripple.swift
@@ -60,7 +60,7 @@ fileprivate struct Ripple: ViewModifier {
 			.fixedSize(horizontal: !isRadial, vertical: !isRadial)
 			.offset(rippleOffset(mX, mY))
 			.scaleEffect(rippleAppeared ? 1 : Self.kRippleStartingScale)
-			.animation(.easeInOut(duration: isRadial ? Self.kRadialReactionDuration : Self.kRippleTouchDownDuration))
+            .animation(.easeInOut(duration: isRadial ? Self.kRadialReactionDuration : Self.kRippleTouchDownDuration),value:rippleAppeared)
 	}
 
 	public func body(content: Content) -> some View
@@ -73,14 +73,14 @@ fileprivate struct Ripple: ViewModifier {
 						RoundedRectangle(cornerRadius: cornerRadius)
 							.fill(color.opacity(pointerState.isOver ? 0.08 : 0))
 							.frame(width: dimension, height: dimension)
-							.animation(.linear(duration: Self.kRippleFadeInOutDuration))
+                            .animation(.linear(duration: Self.kRippleFadeInOutDuration),value:pointerState.isOver)
 					}
 					// ripple
 					if showRipple {
 						RoundedRectangle(cornerRadius: cornerRadius)
 							.fill(color.opacity(0.16))
 							.frame(width: dimension, height: dimension)
-							.animation(.linear(duration: Self.kRippleFadeInOutDuration))
+							.animation(.linear(duration: Self.kRippleFadeInOutDuration),value:pointerState.isOver)
 							.mask(GeometryReader { self.rippleShape(for: $0.size) })
 							.onAppear { self.rippleAppeared = true }
 							.onDisappear { self.rippleAppeared = false }

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -41,7 +41,7 @@ public struct MaterialSwitchToggleStyle: ToggleStyle {
 				.fill(configuration.isOn ? Color.accentColor : Color.white)
 				.frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
 				.offset(offset)
-                .animation(anim,value:configuration.isOn)
+				.animation(anim, value: configuration.isOn)
 				.elevation(2)
 			}
 			.modifier(DisabledFader())

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -46,7 +46,7 @@ public struct MaterialSwitchToggleStyle: ToggleStyle {
 			}
 			.modifier(DisabledFader())
 			.radialRipple(configuration.isOn ? Color.accentColor : Color.primary, offset: offset)
-			.animation(anim,value:configuration.isOn)
+			.animation(anim, value: configuration.isOn)
 			.modifier(PointerObserver(action: { configuration.isOn.toggle() }))
 	}
 

--- a/Sources/MaterialUI/Toggle.swift
+++ b/Sources/MaterialUI/Toggle.swift
@@ -41,12 +41,12 @@ public struct MaterialSwitchToggleStyle: ToggleStyle {
 				.fill(configuration.isOn ? Color.accentColor : Color.white)
 				.frame(width: Self.thumbDiameter, height: Self.thumbDiameter)
 				.offset(offset)
-				.animation(anim)
+                .animation(anim,value:configuration.isOn)
 				.elevation(2)
 			}
 			.modifier(DisabledFader())
 			.radialRipple(configuration.isOn ? Color.accentColor : Color.primary, offset: offset)
-			.animation(anim)
+			.animation(anim,value:configuration.isOn)
 			.modifier(PointerObserver(action: { configuration.isOn.toggle() }))
 	}
 


### PR DESCRIPTION
as things stand, buttons sometimes animate to their starting positions because the button style is providing an animation which is then used by the system for the position.

see this video for an example:
https://www.dropbox.com/s/6am1lkcz79g6xzv/current_animation.mov?dl=0

when the sheet appears - the button animates to the centre spot.

specifying the animation value in elevation.swift fixes this
(essentially telling swiftUI that this animation only applies to changes of elevation

see fixed version:
https://www.dropbox.com/s/gq8ni7ktsm82c2a/fixed_animation.mov?dl=0

I have added specific values everywhere there is an animation as that seems like a good practice to keep the animations encapsulated. I haven't tested on tvos. Also - it's not my code, so please do review and check that I have correctly identified the correct single value which is changing to drive the animations.